### PR TITLE
Unwrap composed component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,13 +35,11 @@ export default (ComposedComponent) => class extends Component {
   render() {
     // pass window dimensions as props to wrapped component
     return (
-      <div>
-        <ComposedComponent
-          {...this.props}
-          windowWidth={this.state.width}
-          windowHeight={this.state.height}
-        />
-      </div>
+      <ComposedComponent
+        {...this.props}
+        windowWidth={this.state.width}
+        windowHeight={this.state.height}
+      />
     );
   }
 


### PR DESCRIPTION
I’m not sure if there’s a particular reason why you’ve wrapped the composed component inside a `div` element, but it looks unnecessary to me. When I use it, it breaks my styling because of the extra `div`. I think you should remove it.