### PR TITLE
Set a display name with the name of the composed component

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,5 +1,36 @@
 /* eslint-disable prefer-arrow-callback, react/prop-types */
 // eslint-disable-next-line no-unused-vars
-// import React, { Component } from 'react';
-// import { mount } from 'enzyme';
-// import { assert } from 'chai';
+import React, { Component } from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import windowSize from '../index';
+
+const ScreenSize = (props) => (
+  <p>
+    Screen width is: {props.windowWidth}
+    <br />
+    Screen height is: {props.windowHeight}
+  </p>
+);
+
+describe('windowSize', () => {
+
+  it('should have a display name with the name of the composed component', () => {
+    const EnhancedComponent = windowSize(ScreenSize);
+    const wrapper = shallow(<div><EnhancedComponent /></div>);
+    assert.equal(wrapper.children().at(0).name(), `windowSize(${ScreenSize.name})`);
+  });
+
+  it('should have a display name with the display name of the composed component if given', () => {
+    ScreenSize.displayName = 'p';
+    try {
+      const EnhancedComponent = windowSize(ScreenSize);
+      const wrapper = shallow(<div><EnhancedComponent /></div>);
+      assert.equal(wrapper.children().at(0).name(), `windowSize(${ScreenSize.displayName})`);
+    }
+    finally {
+      delete ScreenSize.displayName;
+    }
+  });
+
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,45 +2,56 @@
 // the wrapped component
 import React, { Component } from 'react';
 
-export default (ComposedComponent) => class extends Component {
+export default (ComposedComponent) => {
 
-  constructor() {
-    super();
-    this.state = {
-      width: 0,
-      height: 0,
-    };
+  class windowSize extends Component {
+
+    constructor() {
+      super();
+      this.state = {
+        width: 0,
+        height: 0,
+      };
+    }
+
+    handleResize() {
+      // set initial state
+      this.setState({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    componentDidMount() {
+      // bind window resize listeners
+      this._handleResize = this.handleResize.bind(this);
+      this._handleResize();
+      window.addEventListener('resize', this._handleResize);
+    }
+
+    componentWillUnmount() {
+      // clean up listeners
+      window.removeEventListener('resize', this._handleResize);
+    }
+
+    render() {
+      // pass window dimensions as props to wrapped component
+      return (
+        <ComposedComponent
+          {...this.props}
+          windowWidth={this.state.width}
+          windowHeight={this.state.height}
+        />
+      );
+    }
+
   }
 
-  handleResize() {
-    // set initial state
-    this.setState({
-      width: window.innerWidth,
-      height: window.innerHeight,
-    });
-  }
+  const composedComponentName = ComposedComponent.displayName
+    || ComposedComponent.name
+    || 'Component';
 
-  componentDidMount() {
-    // bind window resize listeners
-    this._handleResize = this.handleResize.bind(this);
-    this._handleResize();
-    window.addEventListener('resize', this._handleResize);
-  }
-
-  componentWillUnmount() {
-    // clean up listeners
-    window.removeEventListener('resize', this._handleResize);
-  }
-
-  render() {
-    // pass window dimensions as props to wrapped component
-    return (
-      <ComposedComponent
-        {...this.props}
-        windowWidth={this.state.width}
-        windowHeight={this.state.height}
-      />
-    );
-  }
+  windowSize.displayName = `windowSize(${composedComponentName})`;
+  return windowSize;
 
 };


### PR DESCRIPTION
Using enzyme's shallow rendering, display names are useful to find components.

Since this component returned `_class` as the display name, I updated to set a display name with the name of the composed component according to [Airbnb React/JSX Style Guide](https://github.com/airbnb/javascript/tree/master/react#naming).

