### PR TITLE
Add SSR support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,10 @@ export default (ComposedComponent) => {
 
     constructor() {
       super();
+      const isServer = typeof window === 'undefined';
       this.state = {
-        width: document.body.clientWidth,
-        height: document.body.clientHeight,
+        width: isServer ? null : document.body.clientWidth,
+        height: isServer ? null : document.body.clientHeight,
       };
     }
 


### PR DESCRIPTION
`document` isn't available on the server. This adds a ternary operator that make sure we can still use this component while server-side rendering.