### PR TITLE
React 16 Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-window-size",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "React HOC that passes browser window size to wrapped component",
   "repository": {
     "type": "git",
@@ -43,7 +43,8 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
     "chai": "^3.5.0",
-    "enzyme": "^2.2.0",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.14.0",
     "eslint": "^2.11.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.8.1",
@@ -52,15 +53,15 @@
     "jsdom": "^8.5.0",
     "mocha": "^2.4.5",
     "nodemon": "^1.9.1",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
     "sinon": "^1.17.3"
   },
   "peerDependencies": {
     "react": "~0.14.8 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.6.1"
+    "babel-runtime": "^6.6.1",
+    "test-utils": "^1.1.1"
   }
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -13,13 +13,18 @@ Object.keys(document.defaultView).forEach((property) => {
 global.navigator = {
   userAgent: 'node.js',
 };
+document.body.clientHeight = 768;
+document.body.clientWidth = 1024;
 
 // documentRef = document;
 
 import React from 'react';
-import { mount } from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import { assert } from 'chai';
 import windowSize from '../index';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({ adapter: new Adapter() });
 
 const ScreenSize = (props) => (
   <div>{`===${props.windowWidth}===${props.windowHeight}===`}</div>
@@ -30,7 +35,7 @@ describe('windowSize', () => {
   it('should have a display name with the name of the composed component', () => {
     const EnhancedComponent = windowSize(ScreenSize);
     const wrapper = mount(<div><EnhancedComponent /></div>);
-    assert.equal(wrapper.children().at(0).name(), `windowSize(${ScreenSize.name})`);
+    assert.equal(wrapper.children().at(0).name(), `ForwardRef(windowSize(${ScreenSize.name}))`);
   });
 
   it('should have a display name with the display name of the composed component if given', () => {
@@ -38,7 +43,8 @@ describe('windowSize', () => {
     try {
       const EnhancedComponent = windowSize(ScreenSize);
       const wrapper = mount(<div><EnhancedComponent /></div>);
-      assert.equal(wrapper.children().at(0).name(), `windowSize(${ScreenSize.displayName})`);
+      assert.equal(wrapper.children().at(0).name(),
+        `ForwardRef(windowSize(${ScreenSize.displayName}))`);
     }
     finally {
       delete ScreenSize.displayName;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
 // higher-order component that passes the dimensions of the window as props to
 // the wrapped component
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
-export default (ComposedComponent) => {
-
-  class windowSize extends Component {
-
+function windowSize(Component) {
+  class WindowSize extends React.Component {
     constructor() {
       super();
       this.state = {
@@ -34,29 +33,37 @@ export default (ComposedComponent) => {
       window.removeEventListener('resize', this._handleResize);
     }
 
-    getWrappedInstance() {
-      return this.wrappedInstance;
-    }
-
     render() {
+      const { forwardRef, ...rest } = this.props;
+
       // pass window dimensions as props to wrapped component
       return (
-        <ComposedComponent
-          {...this.props}
-          ref={c => { this.wrappedInstance = c; }}
+        <Component
+          {...rest}
+          ref={forwardRef}
           windowWidth={this.state.width}
           windowHeight={this.state.height}
         />
       );
     }
-
   }
 
-  const composedComponentName = ComposedComponent.displayName
-    || ComposedComponent.name
-    || 'Component';
+  WindowSize.propTypes = {
+    forwardRef: PropTypes.element,
+  };
 
-  windowSize.displayName = `windowSize(${composedComponentName})`;
-  return windowSize;
+  function forwardRef(props, ref) {
+    return <WindowSize {...props} forwardRef={ref} />;
+  }
 
+  const name = Component.displayName || Component.name || 'Component';
+  forwardRef.displayName = `windowSize(${name})`;
+
+  return React.forwardRef(forwardRef);
+}
+
+windowSize.propTypes = {
+  Component: PropTypes.element,
 };
+
+export default windowSize;


### PR DESCRIPTION
Upgraded peer dependency to react 16.3, and use a forwardRef to set a ref to the wrapped component, rather than a regular ref.  This helps it work with function components.

Bump Enzyme to compatible version that works with React 16.  Fix failing test. Bump package version to 2.0.0 since this a breaking change from how refs previously worked.